### PR TITLE
⬆️ 🤖 - Learn to pause  or nothing worthwhile can catch up to you

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ optional = true
 [tool.poetry.group.docs.dependencies]
 sphinx = "7.4.7"
 pydata-sphinx-theme = "0.16.0"
-sphinx-hoverxref = "1.4.1"
+sphinx-hoverxref = "1.4.2"
 sphinx_copybutton = "0.5.2"
 myst_parser = "4.0.0"
 sphinx_design = "^0.6.0"


### PR DESCRIPTION
Auto Release

## Summary by Sourcery

Enhancements:
- Update sphinx-hoverxref dependency from version 1.4.1 to 1.4.2 in pyproject.toml.